### PR TITLE
Fix type instability for small performance improvement

### DIFF
--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -283,7 +283,7 @@ function _emcee(pdf, theta0s, p0s, blob0s, niter_walker, nburnin_walker, nwalker
                                                                (:burnin_phase, n<=0)])
         end
         if n==0 # reset after burnin
-            naccept = fill!(naccept,0)
+            fill!(naccept,0)
             nn = 1
         end
         nn +=1


### PR DESCRIPTION
I noticed a minor type instability when using the `emcee` function.
Changing `naccept = fill!(naccept, 0)` to just `fill!(naccept, 0)` resolved it in my case.

I believe this change should have no impact on the results.

Thanks for the great package!